### PR TITLE
Fix Typo in Header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -53,7 +53,7 @@
     {%- if page_paths -%}
         <div class="sidebar">
           <div class="logo">
-             <a href="https://subsuface-divelog.org"><img src="{{ "assets/subsurface-icon1.png" | relative_url }}"></a>
+             <a href="https://subsurface-divelog.org"><img src="{{ "assets/subsurface-icon1.png" | relative_url }}"></a>
           </div>
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}


### PR DESCRIPTION
Fixes typo in url, so clicking logo on subsurface website actually works instead of breaking.